### PR TITLE
Add sync API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules/
 debug/
 
 dist/
+/sync/
 /wasm
 /worker
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,16 @@
 - The library is able to reset its internal error state, which makes the
   [v2 wiki caveat](https://github.com/mdaines/viz.js/wiki/Caveats#rendering-graphs-with-user-input)
   unnecessary.
-- Rendering from main thread is no longer supported, you must use a worker
-  (webworker or worker_thread).
+- Rendering from main thread is no longer supported on the default async API,
+  you must use a worker (webworker or worker_thread).
 - The JS code is now transpiled from TypeScript, and typings are packed within
   the npm package. You can find the API documentation there!
+- There is a synchronous version available for legacy Node.js support.
 
 ##### Breaking changes and deprecations
 
 - **BREAKING:** Bump required version of Node.js to v12 LTS (might work on v10
-  LTS using CLI flags).
+  LTS using CLI flags or the synchronous API).
 - **BREAKING:** Remove `Viz.prototype.renderSVGElement`. You can use
   `renderString` and `DOMParser` to achieve the same result.
 - **BREAKING:** Remove `Viz.prototype.renderImageElement`. You can use
@@ -40,7 +41,9 @@
   `package.json`#`exports`, you can use the specifier `@aduh95/viz.js/worker`.
 - **BREAKING:** Compiles to WebAssembly, which cannot be bundled in the
   `render.js` file like asm.js used to. Depending on your bundling tool, you may
-  need some extra config to make everything work.
+  need some extra config to make everything work. You might also use the
+  synchronous API, which bundles the asm.js code, although its usage should be
+  strictly limited to Node.js or webworker use.
 - **BREAKING:** Remove ES5 and CJS dist files, all modern browsers now support
   ES2015 modules. If you want to support an older browser, you would need to
   transpile it yourself or use an older version.
@@ -52,7 +55,7 @@
 ##### Added features
 
 - Add support for Node.js `worker_threads`.
-- Refactor JS files to Typescript.
+- Refactor JS files to TypeScript.
 - Refactor `viz.c` to C++ to use
   [Emscripten's Embind](https://emscripten.org/docs/porting/connecting_cpp_and_javascript/embind.html).
 - Use `ALLOW_MEMORY_GROW` compiler option to avoid failing on large graphs.
@@ -61,6 +64,7 @@
   - Remove the need of creating new instances when render fails by resetting
     internal error state.
 - Switch to Mocha and Puppeteer for browser testing.
+- Add synchronous API using asm.js.
 - Upgrade deps:
   - Upgrade Emscripten to 1.39.12
   - Upgrade Graphviz to 2.44.0

--- a/README.md
+++ b/README.md
@@ -52,6 +52,29 @@ async function dot2svg(dot, options = {}) {
 }
 ```
 
+#### Synchronous API
+
+There is a synchronous version of `renderString` method available:
+
+```js
+const vizRenderStringSync = require("@aduh95/viz.js/sync");
+
+console.log(vizRenderStringSync("digraph{1 -> 2 }"));
+```
+
+Key differences with async API:
+
+- It compiles Graphviz to JavaScript instead of `WebAssembly`, this should come
+  with a performance hit and a bigger bundled file size (brotli size is 27%
+  bigger).
+- It is a CommonJS module, while the rest of the API is written as standard
+  ECMAScript modules. The upside is this syntax is supported on a wider Node.js
+  version array.
+
+> Note: Using the sync API on the browser main thread is not recommended, it
+> might degrade the overall user experience of the web page. It is strongly
+> recommended to use web workers – with the sync or the async API.
+
 ### Browsers
 
 You can either use the `worker` or the `workerURL` on the constructor. Note that

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
       "require": "./dist/index.cjs",
       "import": "./dist/index.mjs"
     },
+    "./sync": "./dist/renderSync.js",
     "./wasm": "./dist/render.wasm",
     "./worker": {
       "import": "./dist/render.node.mjs",
@@ -31,6 +32,7 @@
   ],
   "files": [
     "dist/",
+    "sync/",
     "wasm",
     "worker"
   ],

--- a/src/asm.mjs.d.ts
+++ b/src/asm.mjs.d.ts
@@ -1,0 +1,3 @@
+import type { WebAssemblyModule } from "./render";
+
+export default function (): WebAssemblyModule;

--- a/src/asm.mjs.js
+++ b/src/asm.mjs.js
@@ -1,0 +1,1 @@
+// Dummy file for tsc

--- a/src/renderFunction.ts
+++ b/src/renderFunction.ts
@@ -1,0 +1,29 @@
+import type { RenderOptions } from "./types";
+import type { WebAssemblyModule } from "./render";
+
+export default function render(
+  Module: WebAssemblyModule,
+  src: string,
+  options: RenderOptions
+): string {
+  for (const { path, data } of options.files) {
+    Module.vizCreateFile(path, data);
+  }
+
+  Module.vizSetY_invert(options.yInvert ? 1 : 0);
+  Module.vizSetNop(options.nop || 0);
+
+  const resultString = Module.vizRenderFromString(
+    src,
+    options.format,
+    options.engine
+  );
+
+  const errorMessageString = Module.vizLastErrorMessage();
+
+  if (errorMessageString !== "") {
+    throw new Error(errorMessageString);
+  }
+
+  return resultString;
+}

--- a/src/renderSync.ts
+++ b/src/renderSync.ts
@@ -1,0 +1,23 @@
+import Module from "./asm.mjs";
+import render from "./renderFunction.js";
+
+import type { RenderOptions } from "./types";
+
+let asmModule;
+export default function renderStringSync(
+  src: string,
+  options?: RenderOptions
+): string {
+  if (asmModule == null) {
+    asmModule = Module();
+  }
+  return render(asmModule, src, {
+    format: "svg",
+    engine: "dot",
+    files: [],
+    images: [],
+    yInvert: false,
+    nop: 0,
+    ...(options || {}),
+  });
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,15 +1,11 @@
-import type {
-  RenderOptions,
-  SerializedError,
-  RenderResponse,
-  RenderRequest,
-} from "./types";
+import type { SerializedError, RenderResponse, RenderRequest } from "./types";
 import type { Worker } from "worker_threads";
 
 import initializeWasm, {
   WebAssemblyModule,
   EMCCModuleOverrides,
 } from "./render";
+import render from "./renderFunction.js";
 
 /* eslint-disable no-var */
 //
@@ -36,33 +32,6 @@ async function getModule(): Promise<WebAssemblyModule> {
     Module = await asyncModuleOverrides.then(initializeWasm);
   }
   return Module;
-}
-
-function render(
-  Module: WebAssemblyModule,
-  src: string,
-  options: RenderOptions
-): string {
-  for (const { path, data } of options.files) {
-    Module.vizCreateFile(path, data);
-  }
-
-  Module.vizSetY_invert(options.yInvert ? 1 : 0);
-  Module.vizSetNop(options.nop || 0);
-
-  const resultString = Module.vizRenderFromString(
-    src,
-    options.format,
-    options.engine
-  );
-
-  const errorMessageString = Module.vizLastErrorMessage();
-
-  if (errorMessageString !== "") {
-    throw new Error(errorMessageString);
-  }
-
-  return resultString;
 }
 
 export function onmessage(event: MessageEvent): Promise<void> {

--- a/test/integration.ts
+++ b/test/integration.ts
@@ -4,6 +4,7 @@
  */
 
 import Viz from "@aduh95/viz.js";
+import vizRenderStringSync from "@aduh95/viz.js/sync";
 
 // @ts-expect-error
 Viz({ workerURL: "string" });
@@ -50,3 +51,17 @@ viz.terminateWorker();
 
 // @ts-expect-error
 viz.terminateWorker("argument");
+
+// @ts-expect-error
+vizRenderStringSync();
+
+vizRenderStringSync("string");
+// @ts-expect-error
+vizRenderStringSync("string").then(() => {});
+vizRenderStringSync("string").replace("string", "");
+vizRenderStringSync("string", {});
+vizRenderStringSync("string", { format: "dot" });
+// @ts-expect-error
+vizRenderStringSync("string", { format: "unknown" });
+// @ts-expect-error
+vizRenderStringSync("string", { unknown: "unknown" });

--- a/test/node.js
+++ b/test/node.js
@@ -34,4 +34,21 @@ describe("Test graph rendering using Node.js", function () {
       .then((result) => assert.ok(result))
       .finally(() => viz.terminateWorker());
   });
+
+  it("should render a graph using sync version", function () {
+    const renderStringSync = require("@aduh95/viz.js/sync");
+
+    assert.ok(renderStringSync("digraph { a -> b; }"));
+  });
+
+  it("should render same graph using async and sync versions", async function () {
+    const viz = await getViz();
+    const renderStringSync = require("@aduh95/viz.js/sync");
+
+    const resultSync = renderStringSync("digraph { a -> b; }");
+    return viz
+      .renderString("digraph { a -> b; }")
+      .then((result) => assert.strictEqual(result, resultSync))
+      .finally(() => viz.terminateWorker());
+  });
 });


### PR DESCRIPTION
Adds a sync version of the `renderString` method:

```js
const vizRenderStringSync = require("@aduh95/viz.js/sync");
console.log(vizRenderStringSync("digraph{1 -> 2 }"));
```

Key differences with async API:

- It uses `asm.js` instead of `WebAssembly`, this should come with a performance
  hit and a bigger bundled file size.
- It is a CommonJS module, while the rest of the API is written as standard
  ECMAScript modules. The upside is this syntax is supported on a wider Node.js
  version array.

Fixes #1 