### PR TITLE
browser: auto-instanciate wasm with default option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### @aduh95/Viz.js v3.1.0 (unreleased)
+
+- Auto-init WASM in `render.browser.js`
+  ([#9](https://github.com/aduh95/viz.js/pull/9))
+
 ### @aduh95/Viz.js v3.0.2 (2020-07-09)
 
 - Update Graphviz to

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -57,21 +57,13 @@ export function onmessage(event: MessageEvent): Promise<void> {
 }
 
 if (ENVIRONMENT_IS_WORKER) {
-  let resolveModuleOverrides: (value?: EMCCModuleOverrides) => void;
-  asyncModuleOverrides = new Promise((done) => {
-    resolveModuleOverrides = done;
-  });
+  // Default to no overrides
+  asyncModuleOverrides = Promise.resolve({});
+
   exports = (
     moduleOverrides: EMCCModuleOverrides
   ): Promise<EMCCModuleOverrides> => {
-    if (resolveModuleOverrides) {
-      resolveModuleOverrides(moduleOverrides);
-      return asyncModuleOverrides;
-    } else {
-      return Promise.resolve().then(
-        () => exports(moduleOverrides) as Promise<any>
-      );
-    }
+    return (asyncModuleOverrides = Promise.resolve(moduleOverrides));
   };
   addEventListener("message", onmessage);
 } else if (ENVIRONMENT_IS_NODE) {


### PR DESCRIPTION
While preserving the possibility to override default options, it makes it
possible to use the `render.browser.js` file out of the box.

Fixes: https://github.com/aduh95/viz.js/issues/8