### PR TITLE
Remove `dist` from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ prefix-full/
 prefix-lite/
 sources/
 
-dist/
 /async/
 /sync/
 /wasm


### PR DESCRIPTION
You have all your builds and type files pointed at `dist`, but `dist` is in `.gitignore` and isn't committed.  This means the library cannot be used after being installed from NPM, as the referenced resources do not actually exist.

This removes dist from gitgnore, which will allow your build residues into github, and thus into npm.  I have not subsequently rebuilt; I hope you will, and will re-publish afterwards.

This PR addresses part of #23, but I cannot re-build or re-publish