### PR TITLE
fix: disable the emscriptem error handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ build/render.o: src/viz.cpp | build
 	$(CC) $(CC_FLAGS) -o $@ $< $(CC_INCLUDES)
 
 build/asm.js build/asm: USE_CLOSURE:=0
-build/asm.js: LINK_FLAGS+= -s WASM=0 -s WASM_ASYNC_COMPILATION=0 -s TEXTDECODER=1 --memory-init-file 0
+build/asm.js: LINK_FLAGS+= -s WASM=0 -s WASM_ASYNC_COMPILATION=0 -s TEXTDECODER=1 -sNODEJS_CATCH_EXIT=0 -sNODEJS_CATCH_REJECTION=0 --memory-init-file 0
 build/node/render.mjs: LINK_FLAGS+= -s USE_ES6_IMPORT_META=0
 build/browser/render.mjs: | build/browser
 build/node/render.mjs: | build/node


### PR DESCRIPTION
This makes the following stack trace legible, instead of printing out all of the viz.js source code

fixes #32 

```
% cat test.js
import vizRenderSync from "@aduh95/viz.js/sync";

function f() {
  return (undefined).a.b
}

f()

[0] % node test.js
file:///home/rtpg/proj/viz.js/test.js:4
  return (undefined).a.b
                     ^

TypeError: Cannot read property 'a' of undefined
    at f (file:///home/rtpg/proj/viz.js/test.js:4:22)
    at file:///home/rtpg/proj/viz.js/test.js:7:1
    at ModuleJob.run (internal/modules/esm/module_job.js:183:25)
    at async Loader.import (internal/modules/esm/loader.js:178:24)
    at async Object.loadESM (internal/process/esm_loader.js:68:5)
```

